### PR TITLE
Fixed bug in RemoveFromRoleAsync

### DIFF
--- a/src/Stores/UserStore/RemoveClaimsAsync.cs
+++ b/src/Stores/UserStore/RemoveClaimsAsync.cs
@@ -53,7 +53,7 @@ namespace Mobsites.Cosmos.Identity
                     {
                         if (!string.IsNullOrEmpty(user.FlattenClaims))
                         {
-                            user.FlattenClaims.Replace($"{userClaim.ClaimType}|{userClaim.ClaimValue},", string.Empty);
+                            user.FlattenClaims = user.FlattenClaims.Replace($"{userClaim.ClaimType}|{userClaim.ClaimValue},", string.Empty);
                         }
                     }
                 }

--- a/src/Stores/UserStore/RemoveFromRoleAsync.cs
+++ b/src/Stores/UserStore/RemoveFromRoleAsync.cs
@@ -56,11 +56,11 @@ namespace Mobsites.Cosmos.Identity
                         // Update user object (default UserManager will actually call UpdateUserAsync(user).
                         if (!string.IsNullOrEmpty(user.FlattenRoleNames))
                         {
-                            user.FlattenRoleNames.Replace(role.Name + ",", string.Empty);
+                            user.FlattenRoleNames = user.FlattenRoleNames.Replace(role.Name + ",", string.Empty);
                         }
                         if (!string.IsNullOrEmpty(user.FlattenRoleIds))
                         {
-                            user.FlattenRoleIds.Replace(role.Id + ",", string.Empty);
+                            user.FlattenRoleIds = user.FlattenRoleIds.Replace(role.Id + ",", string.Empty);
                         }
                     }
                 }

--- a/src/Stores/UserStore/ReplaceClaimAsync.cs
+++ b/src/Stores/UserStore/ReplaceClaimAsync.cs
@@ -60,7 +60,7 @@ namespace Mobsites.Cosmos.Identity
                 {
                     if (!string.IsNullOrEmpty(user.FlattenClaims))
                     {
-                        user.FlattenClaims.Replace($"{oldClaim.ClaimType}|{oldClaim.ClaimValue}", $"{newClaim.Type}|{newClaim.Value}");
+                        user.FlattenClaims = user.FlattenClaims.Replace($"{oldClaim.ClaimType}|{oldClaim.ClaimValue}", $"{newClaim.Type}|{newClaim.Value}");
                     }
                 }
             }


### PR DESCRIPTION
The `FlattenRoleNames` and `FlattenRoleIds` properties were not updated when user role was removed.